### PR TITLE
Changed podspec summary

### DIFF
--- a/RMPScrollingMenuBarController.podspec
+++ b/RMPScrollingMenuBarController.podspec
@@ -10,7 +10,7 @@
 Pod::Spec.new do |s|
   s.name             = "RMPScrollingMenuBarController"
   s.version          = "1.0.0"
-  s.summary          = "A short description of RMPScrollingMenuBarController."
+  s.summary          = "A scrollable menu bar and multiple view controllers, which is managed like a UITabBarController."
   s.description      = <<-DESC
                       `RMPScrollingMenuBarController` has a scrollable menu bar, and multiple view controllers.
 


### PR DESCRIPTION
`pod lib lint` says this warning. so i changed podspec summary.

```
 -> RMPScrollingMenuBarController (1.0.0)
    - WARN  | [summary] The summary is not meaningful.

[!] RMPScrollingMenuBarController did not pass validation.
You can use the `--no-clean` option to inspect any issue.
```
