### PR TITLE
Fixed indicatorView y-pos is displaced when menubar height changed.

### DIFF
--- a/Pod/Classes/RMPScrollingMenuBar.m
+++ b/Pod/Classes/RMPScrollingMenuBar.m
@@ -528,6 +528,12 @@
     _barHeight = barHeight;
     
     [self sizeToFit];
+
+    // indicatorView repositioning.
+    CGRect frame = _indicatorView.frame;
+    frame.origin.y = self.bounds.size.height - 4;
+    _indicatorView.frame = frame;
+    
     [self layoutIfNeeded];
 }
 


### PR DESCRIPTION
Reposition indicatorView y-position when RMPScrollingMenuBar#barHeight changed.
### Before fix

![simulator screen shot oct 8 2015 00 02 42](https://cloud.githubusercontent.com/assets/648815/10342041/362c6e10-6d52-11e5-9af7-5d07464c5f86.png)
### After fix

![simulator screen shot oct 8 2015 00 03 04](https://cloud.githubusercontent.com/assets/648815/10342046/382f88e6-6d52-11e5-954f-8519f22e4d3d.png)
