### PR TITLE
Fix swipe to back transition

### DIFF
--- a/Pod/Classes/RMPScrollingMenuBarControllerAnimator.m
+++ b/Pod/Classes/RMPScrollingMenuBarControllerAnimator.m
@@ -113,6 +113,9 @@
     // Remove animations
     [fromViewController.view.layer removeAllAnimations];
     [toViewController.view.layer removeAllAnimations];
+    
+    _transitionContext.containerView.layer.beginTime = 0.0;
+    _transitionContext.containerView.layer.timeOffset = 0.0;
 }
 
 


### PR DESCRIPTION
- Put RMPScrollingMenuBarController in navigation controller.
- Change controllers with swipe gesture inside RMPScrollingMenuBarController.
- Use swipe to back gesture to go to the previous controller in the navigation controller
# Before fix:

![bug](https://cloud.githubusercontent.com/assets/274618/11295333/d631afce-8f7b-11e5-8f36-f243586c4d1a.gif)
# After fix:

![nobug](https://cloud.githubusercontent.com/assets/274618/11295339/dd7ca57c-8f7b-11e5-979d-655dcd72ccc6.gif)
